### PR TITLE
プロフィール編集機能のデザインとバリデーションに関する修正

### DIFF
--- a/app/assets/stylesheets/style.scss
+++ b/app/assets/stylesheets/style.scss
@@ -100,7 +100,7 @@ footer {
   object-fit: cover;
 }
 
-.show-profile-image-wrapper, .edit-profile-image-wrapper, .edit-profile-btn-wrapper {
+.show-profile-image-wrapper, .edit-profile-image-wrapper {
   text-align: center;
 }
 
@@ -144,10 +144,6 @@ footer {
 .edit-profile-textarea {
   height: calc( 1.3rem * 5 );
   line-height: 1.3;
-}
-
-.edit-profile-btn {
-  width: 45%;
 }
 
 /* walking_routes#index */

--- a/app/assets/stylesheets/style.scss
+++ b/app/assets/stylesheets/style.scss
@@ -132,7 +132,7 @@ footer {
   margin-bottom: 0;
 }
 
-.edit-profile-image:hover {
+.edit-image:hover {
   filter: brightness(70%);
   cursor: pointer;
 }

--- a/app/javascript/custom/custom.js
+++ b/app/javascript/custom/custom.js
@@ -1,18 +1,18 @@
+// profiles#edit
 if (document.querySelector(".image-uploader")) {
-  window.addEventListener("load", () => {
-    const uploader = document.querySelector(".image-uploader");
-    uploader.addEventListener("change", () => {
-      const upload_file = uploader.files[0];
-      const reader = new FileReader();
-      reader.readAsDataURL(upload_file);
-      reader.addEventListener("load", () => {
-        const upload_image = reader.result;
-        document.querySelector(".edit-profile-image").setAttribute("src", upload_image);
-      });
+  const uploader = document.querySelector(".image-uploader");
+  uploader.addEventListener("change", () => {
+    const upload_file = uploader.files[0];
+    const reader = new FileReader();
+    reader.readAsDataURL(upload_file);
+    reader.addEventListener("load", () => {
+      const upload_image = reader.result;
+      document.querySelector(".edit-image").setAttribute("src", upload_image);
     });
   });
 };
 
+// walking_routes#show
 function walking_route_delete_check_form() {
   if(window.confirm('このルートを削除しますか？')){
     return true;

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -24,5 +24,5 @@ class User < ApplicationRecord
     end
   end
 
-  validates :comment, length: { maximum: 140 }, allow_blank: true
+  validates :comment, with_line_break: { maximum: 140 }, allow_blank: true
 end

--- a/app/views/profiles/edit.html.erb
+++ b/app/views/profiles/edit.html.erb
@@ -8,7 +8,7 @@
           <div class="col-lg-2 edit-profile-image-wrapper">
             <div class="mb-2">
               <%= f.label :profile_image do %>
-                <%= image_tag @user.profile_image.url, class: 'profile-image edit-profile-image' %>
+                <%= image_tag @user.profile_image.url, class: 'profile-image edit-image' %>
                 <%= f.file_field :profile_image, class: "image-uploader", style: "display: none;" %>
               <% end %>
             </div>

--- a/app/views/profiles/edit.html.erb
+++ b/app/views/profiles/edit.html.erb
@@ -38,8 +38,8 @@
             </div>
           </div>
         </div>
-        <div class="edit-profile-btn-wrapper">
-          <%= f.submit "更新する", class: "btn btn-primary btn--extend edit-profile-btn" %>
+        <div class="d-grid gap-2 col-md-6 mx-auto">
+          <%= f.submit "更新", class: "btn btn-primary btn--extend" %>
         </div>
       <% end %>
     </div>

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe User, type: :model do
     it "140文字を超えるcommentは無効であること" do
       user.comment = Faker::Lorem.paragraph_by_chars(number: 141)
       user.valid?
-      expect(user.errors.full_messages).to include("自己紹介は140文字以内で入力してください")
+      expect(user.errors.full_messages).to include("自己紹介140文字以内")
     end
 
     it "commentは空白でも有効であること" do

--- a/spec/system/profiles_spec.rb
+++ b/spec/system/profiles_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe "Profiles", type: :system do
 
         fill_in "ユーザー名", with: "new_name"
         fill_in "自己紹介", with: "new_comment"
-        click_button "更新する"
+        click_button "更新"
 
         expect(page).to have_selector ".show-profile-name", text: "new_name"
         expect(page).to have_selector ".show-profile-comment", text: "new_comment"


### PR DESCRIPTION
## Issue
Closes #7

## 内容

### 既存機能修正

- プロフィール編集
  - 更新ボタンのレスポンシブデザインを修正
  - 画像アップロードプレビュー機能のためのJavaScriptについて、不要なloadイベント削除

### RSpec修正

- Model Spec
  - Userモデルのcommentの文字数バリデーションについて、#6 で実装したwith_line_break_validatorを適用
